### PR TITLE
Make s3 permissions configurable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -151,9 +151,9 @@ data "aws_iam_policy_document" "s3_access_for_sftp_users" {
 
     actions = [
       "s3:PutObject",
-      #      "s3:GetObject",
-      #      "s3:DeleteObject",
-      #      "s3:DeleteObjectVersion",
+      "s3:GetObject",
+      "s3:DeleteObject",
+      "s3:DeleteObjectVersion",
       "s3:GetObjectVersion",
       "s3:GetObjectACL",
       "s3:PutObjectACL"

--- a/main.tf
+++ b/main.tf
@@ -149,15 +149,7 @@ data "aws_iam_policy_document" "s3_access_for_sftp_users" {
     sid    = "HomeDirObjectAccess"
     effect = "Allow"
 
-    actions = [
-      "s3:PutObject",
-      "s3:GetObject",
-      "s3:DeleteObject",
-      "s3:DeleteObjectVersion",
-      "s3:GetObjectVersion",
-      "s3:GetObjectACL",
-      "s3:PutObjectACL"
-    ]
+    actions = var.s3_bucket_permissions
 
     resources = [
       "${join("", data.aws_s3_bucket.landing[*].arn)}/${each.value}/*"

--- a/variables.tf
+++ b/variables.tf
@@ -128,3 +128,9 @@ variable "host_key" {
   description = "Host key for ssh"
   default     = ""
 }
+
+variable "s3_bucket_permissions" {
+  type        = list(string)
+  description = "The permissions set on the backing bucket for the user's home directory. Defaults to not allow deletion or downloads."
+  default     = ["s3:PutObject", "s3:PutObjectACL", "s3:GetObjectACL"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -132,5 +132,5 @@ variable "host_key" {
 variable "s3_bucket_permissions" {
   type        = list(string)
   description = "The permissions set on the backing bucket for the user's home directory. Defaults to not allow deletion or downloads."
-  default     = ["s3:PutObject", "s3:PutObjectACL", "s3:GetObjectACL"]
+  default     = ["s3:PutObject", "s3:PutObjectACL", "s3:GetObjectACL", "s3:GetObjectVersion"]
 }


### PR DESCRIPTION
## what
* Make the s3 bucket permissions configurable via var
* Default to locked down permission where only uploads are allowed

## why
* Give ability to spin up more or less restrictive SFTP servers
