### PR TITLE
Allow the kafka workflow to be disabled if not needed

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,4 @@
 locals {
-  enabled = module.this.enabled
-
   is_vpc                 = var.vpc_id != null
   security_group_enabled = module.this.enabled && var.security_group_enabled
   user_names             = keys(var.sftp_users)
@@ -225,6 +223,8 @@ resource "aws_iam_role" "logging" {
 }
 
 resource "aws_iam_role" "sftp_transfer_role" {
+  count = var.kafka_lambda_enabled ? 1 : 0
+
   name = "SFTPTransferRole"
   
   assume_role_policy = <<EOF
@@ -301,6 +301,7 @@ data "aws_region" "current" {}
 
 
 resource "aws_iam_role" "iam_for_lambda" {
+  count = var.kafka_lambda_enabled ? 1 : 0
   name = "push_to_kafka"
 
   assume_role_policy = <<EOF
@@ -378,6 +379,7 @@ EOF
 }
 
 resource "aws_lambda_function" "push_to_kafka" {
+  count = var.kafka_lambda_enabled ? 1 : 0
   function_name = "push_to_kafka"
   filename = var.lambda_zip
   role = aws_iam_role.iam_for_lambda.arn
@@ -396,6 +398,7 @@ resource "aws_lambda_function" "push_to_kafka" {
 }
 
 resource "aws_transfer_workflow" "kafka" {
+  count = var.kafka_lambda_enabled ? 1 : 0
   description = "kafka"
   steps {
     custom_step_details {

--- a/main.tf
+++ b/main.tf
@@ -35,11 +35,14 @@ resource "aws_transfer_server" "default" {
       address_allocation_ids = var.eip_enabled ? aws_eip.sftp.*.id : var.address_allocation_ids
     }
   }
-  workflow_details {
-    count = var.kafka_lambda_enabled ? 1 : 0
-    on_upload {
-      execution_role = aws_iam_role.sftp_transfer_role[count.index].arn
-      workflow_id = aws_transfer_workflow.kafka[count.index].id
+  dynamic workflow_details {
+    for_each = var.kafka_lambda_enabled ? [1] : []
+    
+    content {
+      on_upload {
+        execution_role = aws_iam_role.sftp_transfer_role[count.index].arn
+        workflow_id = aws_transfer_workflow.kafka[count.index].id
+      }
     }
   }
     

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,6 @@
 locals {
+  enabled = module.this.enabled
+  
   is_vpc                 = var.vpc_id != null
   security_group_enabled = module.this.enabled && var.security_group_enabled
   user_names             = keys(var.sftp_users)

--- a/variables.tf
+++ b/variables.tf
@@ -159,3 +159,8 @@ variable kafka_queue {
   type = string
   description = "name of kafka queue to write to"
 }
+
+variable kafka_lambda_enabled {
+  type = bool
+  description = "If a kafka lambda is enabled as part of the workflow"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -138,29 +138,35 @@ variable "s3_bucket_permissions" {
 variable "vpc_private_subnet_ids" {
   type = list(string)
   description = "List of subnet ids"
+  default = []
 }
 
 variable "lambda_zip" {
   type = string
   description = "filename of zip file of lambda function"
+  default = ""
 }
 
 variable lambda_handler {
   type = string
   description = "entrypoint into lambda function"
+  default = ""
 }
 
 variable kafka_rest_server {
   type = string
   description = "URI of kafka rest server"
+  default = ""
 }
 
 variable kafka_queue {
   type = string
   description = "name of kafka queue to write to"
+  default = ""
 }
 
 variable kafka_lambda_enabled {
   type = bool
   description = "If a kafka lambda is enabled as part of the workflow"
+  default = true
 }


### PR DESCRIPTION
## what
* Add default empty values to all kafka/workflow vars
* Add a single variable `kafka_lambda_enabled` that will disable the setup of the workflow + Kafka transfer step and any associated config

## why
* Allows use of the same module without the kafka/workflow config if not needed
